### PR TITLE
Rewrite the plugin.  

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Leo Liang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.markdown
+++ b/README.markdown
@@ -1,21 +1,35 @@
 # Jekyll Revision History Plugin
 
-Adds recent revision history to each page on Jekyll/Octopress site. 
+Page/post revision history for Jekyll/Octopress site. 
 
 Git is the only revision control system currently supported.  
 
+This plugin adds a page variable `page.revisions`, which is a list of recent revisions of the post or page. Each revision contains attributes `date`, `author` and `message`. A page variable `page.last_modified_at` is added as well, which equals to `page.revisions[0].date`. 
 
-This plugin adds a page variable `page.revisions`, which is a list of recent revisions of the post or page. Each revision contains attributes `date`, `author` and `message`. The sample template file `revision.html` shows how to use the variable.
+The sample template file `revision.html` and `recent_updated.html` shows how to use the variable.
 
-## Installation
+## Usage
 
 Put `revision.rb` in `/_plugins/` (for Jekyll) or `/plugins/` (for Octopress) directory. 
 
-Put `revision.html` in `/_include` (for Jekyll) or `/source/_include` (for Octopress) directory. Include it somewhere in your layout file:
+Put `revision.html` and `recent_updated.html` in `/_include` (for Jekyll) or `/source/_include` (for Octopress) directory. 
+
+### Revision History
+
+Include `revision.html` somewhere in your layout file:
 
 	{% include revision.html %}
 
-You may modify `revision.html` to get the presentation you want.
+It lists the revision history of the current post/page. You may modify `revision.html` to get the presentation you want.
+
+### Recent Updates
+
+Include `recent_updated.html` somewhere in your layout file:
+
+	{% include recent_updated.html %}
+
+It lists 10 most recent updated pages and posts in your site. You may modify `recent_updated.html` to get the presentation you want.
+
 
 ## Configuration
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,46 +1,33 @@
-## Show Post's Revision History For Jekyll/Octopress Powered Sites
+# Jekyll Revision History Plugin
 
-This plugin provide a Liquid tag to generate blog post's revision history, which
-are nothing but commit messages when you do `git commit`. See [this blog
-post][blog] for more information and also as a demo.
+Adds recent revision history to each page on Jekyll/Octopress site. 
 
-[blog]: http://jhshi.me/2013/11/17/post-revision-plugin-for-octopress/
-
-### Installation
-Put `revision.rb` to your `/_plugins/` (for Jekyll) or `/plugins/` (for
-Octopress) directory of your blog source root. Require installation of
-[jekyll-date-format][df].
-
-[df]: https://github.com/imathis/jekyll-date-format
-
-### Configuration
-If your blog source are hosted on Github, you can set two optional
-configurations in your `_config.yml`. Then this plugin will also generate links
-to Github commit history for each post.
-
-- `github_user`: your user name on Github
-- `github_repo`: your blog source repo name on Github. More specifically, for Jekyll sites
-  hosted on Github Pages, this should be `SOMEBODY.github.[io][com]`.
+Git is the only revision control system currently supported.  
 
 
-### Usage
-Put `revision.html` somewhere in your `_include` (for Jekyll) or
-`source/_include` (for Octopress) directory. And include this html file
-somewhere in your post layout file.
+This plugin adds a page variable `page.revisions`, which is a list of recent revisions of the post or page. Each revision contains attributes `date`, `author` and `message`. The sample template file `revision.html` shows how to use the variable.
 
-One optional argument, `limit`, is accepted by the `revision` tag. It specifies
-the maximum `git-log` number. It's default value is 5.
+## Installation
 
+Put `revision.rb` in `/_plugins/` (for Jekyll) or `/plugins/` (for Octopress) directory. 
 
-### Notes
+Put `revision.html` in `/_include` (for Jekyll) or `/source/_include` (for Octopress) directory. Include it somewhere in your layout file:
 
-When generate Github commit history links, this plugin assumes that:
+	{% include revision.html %}
 
-- If you specify `source` in your `_config.yml`, then blog posts are in
-  `source/_posts` directory. (For Octopress sites)
+You may modify `revision.html` to get the presentation you want.
 
-- Otherwise, blog posts should be in `_posts` directory. (For Jekyll sites)
+## Configuration
 
-If this assumption is not right in your case, then you'll probably need to tweak
-the url patterns a little bit.
+Add below configuration into `_config.yaml`:
 
+	revision:
+	  max_count: 5
+
+`max_count` is the maximum number of revisions to show. Default is 5 if not set.
+
+## Disable
+
+On site generation, this plugin executes `git log` for every document to retrieve revision history. It takes time when there are a lot of posts. You may disable this plugin during local preview by passing `-- --no-revision` to jekyll startup command.
+
+	$ jekyll serve -- --no-revision

--- a/plugins/revision.rb
+++ b/plugins/revision.rb
@@ -11,6 +11,7 @@ module Jekyll
         %w(posts pages docs_to_write).each do |type|
           site.send(type).each do |item|
             item.data['revisions'] = GitLogger.new(site.source, item.path, site.config['revision']).revisions
+            item.data['last_modified_at'] = item.data['revisions'][0]['date']
           end
         end
       end

--- a/source/_includes/post/revision.html
+++ b/source/_includes/post/revision.html
@@ -1,4 +1,0 @@
-<section>
-  <h1> Change History </h1>
-  {% revision limit:5 %}
-</section>

--- a/source/_includes/recent_updated.html
+++ b/source/_includes/recent_updated.html
@@ -1,0 +1,8 @@
+<ul>
+{% assign recentPages = site.pages | sort: 'last_modified_at' | reverse %}
+{% for page in recentPages limit:10 %}
+  <li>
+    <a href="{{ page.url }}">{{ page.title }}</a>
+  </li>
+{% endfor %}
+</ul>

--- a/source/_includes/revision.html
+++ b/source/_includes/revision.html
@@ -1,0 +1,12 @@
+{% if page.revisions.size > 0 %}
+<section>
+  <ul>
+  {% for rev in page.revisions %}
+    <li>
+      <div class="post-meta">{{ rev.date | date_to_string }} -
+      <span class="post-author">{{ rev.author }}</span> - {{ rev.message }}</div>
+    </li>
+  {% endfor %}
+  </ul>
+</section>
+{% endif %}


### PR DESCRIPTION
I've modified your plugin a lot. Just check if it's interesting to you.

The major motivation to rewrite is to make revisions information available to template through a page variable, so that the generated HTML can be customized instead of hard-code inside the plugin. Another reason is: I'm using Jekyll, however the latest version of octopress-date-format doesn't support Jekyll any more. So I remove the dependency to octopress-date-format.

A limitation is that it lacks Github link which was supported in your plugin. Maybe easy to add, but I don't use it right now.
